### PR TITLE
KA21 ログイン有無で編集系ボタンを表示切り替え

### DIFF
--- a/__tests__/HouseworkDetail.test.tsx
+++ b/__tests__/HouseworkDetail.test.tsx
@@ -10,76 +10,6 @@ initTestHelpers()
 
 const handlers = [
   rest.get(
-    `${process.env.NEXT_PUBLIC_RESTAPI_URL}api/houseworks/`,
-    (req, res, ctx) => {
-      return res(
-        ctx.status(200),
-        ctx.json([
-          {
-            id: 1,
-            housework_name: 'dummy data 1',
-            category: {
-              id: 1,
-              category: '衣',
-            },
-            description: 'mock api request data 1',
-            estimated_time: 5,
-            create_user: 1,
-          },
-          {
-            id: 2,
-            housework_name: 'dummy data 2',
-            category: {
-              id: 2,
-              category: '食',
-            },
-            description: 'mock api request data 2',
-            estimated_time: 10,
-            create_user: 1,
-          },
-        ])
-      )
-    }
-  ),
-  rest.get(
-    `${process.env.NEXT_PUBLIC_RESTAPI_URL}api/houseworks/1/`,
-    (req, res, ctx) => {
-      return res(
-        ctx.status(200),
-        ctx.json({
-          id: 1,
-          housework_name: 'dummy data 1',
-          category: {
-            id: 1,
-            category: '衣',
-          },
-          description: 'mock api request data 1',
-          estimated_time: 5,
-          create_user: 1,
-        })
-      )
-    }
-  ),
-  rest.get(
-    `${process.env.NEXT_PUBLIC_RESTAPI_URL}api/houseworks/2/`,
-    (req, res, ctx) => {
-      return res(
-        ctx.status(200),
-        ctx.json({
-          id: 2,
-          housework_name: 'dummy data 2',
-          category: {
-            id: 2,
-            category: '食',
-          },
-          description: 'mock api request data 2',
-          estimated_time: 10,
-          create_user: 1,
-        })
-      )
-    }
-  ),
-  rest.get(
     `${process.env.NEXT_PUBLIC_RESTAPI_URL}api/list-housework/`,
     (req, res, ctx) => {
       return res(
@@ -197,5 +127,21 @@ describe(`housework/[id].js test`, () => {
     await screen.findByText('Housework')
     userEvent.click(screen.getByTestId('back-housework'))
     expect(await screen.findByText('Housework Page')).toBeInTheDocument()
+  })
+
+  it('Should render delete/update button when logged in ', async () => {
+    document.cookie = 'access_token=123xyz'
+    const { page } = await getPage({ route: '/houseworks/1' })
+    render(page)
+    expect(await screen.findByText('Housework Detail')).toBeInTheDocument()
+    expect(screen.getByText('update')).toBeInTheDocument()
+    expect(screen.getByTestId('delete-button')).toBeInTheDocument()
+  })
+  it('Should not render delete/update button when logged out ', async () => {
+    const { page } = await getPage({ route: '/houseworks/1' })
+    render(page)
+    expect(await screen.findByText('Housework Detail')).toBeInTheDocument()
+    expect(screen.queryByText('update')).toBeNull()
+    expect(screen.queryByTestId('delete-button')).toBeNull()
   })
 })

--- a/__tests__/HouseworkPage.test.tsx
+++ b/__tests__/HouseworkPage.test.tsx
@@ -4,6 +4,7 @@ import { getPage } from 'next-page-tester'
 import { initTestHelpers } from 'next-page-tester'
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
+import { isTypedArray } from 'util/types'
 
 initTestHelpers()
 
@@ -82,6 +83,8 @@ beforeAll(() => {
 afterEach(() => {
   server.resetHandlers()
   cleanup()
+  document.cookie =
+    'access_token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;'
 })
 afterAll(() => {
   server.close()
@@ -96,5 +99,20 @@ describe(`Housework-page test`, () => {
     expect(await screen.findByText('Housework Page')).toBeInTheDocument()
     expect(screen.getByText('dummy data 1')).toBeInTheDocument()
     expect(screen.getByText('dummy data 2')).toBeInTheDocument()
+  })
+
+  it('Should display ”新規作成” link in the housework-page when logged in', async () => {
+    document.cookie = 'access_token=123xyz'
+    const { page } = await getPage({ route: '/housework-page' })
+    render(page)
+    expect(await screen.findByText('Housework Page')).toBeInTheDocument()
+    expect(screen.getByText('新規Housework')).toBeInTheDocument()
+  })
+
+  it('Should not display ”新規作成” link in the housework-page when logged out', async () => {
+    const { page } = await getPage({ route: '/housework-page' })
+    render(page)
+    expect(await screen.findByText('Housework Page')).toBeInTheDocument()
+    expect(screen.queryByText('新規Housework')).toBeNull()
   })
 })

--- a/components/HouseworkForm.tsx
+++ b/components/HouseworkForm.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
 import { StateContext } from '../context/StateContext'
 import { HOUSEWORK } from '../types/Types'
@@ -22,12 +22,16 @@ const HouseworkForm: React.FC<ContextHousework> = ({
   housework,
 }) => {
   const { selectedHousework, setSelectedHousework } = useContext(StateContext)
+  const [hasToken, setHasToken] = useState(false)
   const apiUrl = `${process.env.NEXT_PUBLIC_RESTAPI_URL}api/houseworks/`
   const router = useRouter()
 
   useEffect(() => {
     if (housework) {
       setSelectedHousework(housework)
+    }
+    if (cookie.get('access_token')) {
+      setHasToken(true)
     }
   }, [])
 
@@ -156,33 +160,38 @@ const HouseworkForm: React.FC<ContextHousework> = ({
         />
 
         <div className="flex justify-around">
-          {/* delete button */}
-          <div className="flex cursor-pointer mt-3">
-            <svg
-              className="w-6 h-6 cursor-pointer"
-              onClick={deleteHousework}
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-              />
-            </svg>
-          </div>
+          {hasToken && (
+            // delete button
+            <div className="flex cursor-pointer mt-3">
+              <svg
+                className="w-6 h-6 cursor-pointer"
+                data-testid="delete-button"
+                onClick={deleteHousework}
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                />
+              </svg>
+            </div>
+          )}
 
-          {/* create / update button */}
-          <button
-            type="submit"
-            className="text-sm px-2 py-1 mt-2
-                    bg-blue-300 hover:bg-blue-400 rounded uppercase"
-          >
-            {selectedHousework.id !== 0 ? 'update' : 'create'}
-          </button>
+          {hasToken && (
+            // create/update button
+            <button
+              type="submit"
+              className="text-sm px-2 py-1 mt-2
+              bg-blue-300 hover:bg-blue-400 rounded uppercase"
+            >
+              {selectedHousework.id !== 0 ? 'update' : 'create'}
+            </button>
+          )}
         </div>
       </form>
     </section>

--- a/pages/housework-page.tsx
+++ b/pages/housework-page.tsx
@@ -57,26 +57,28 @@ const HouseworkList: NextPage<STATICPROPS> = ({ staticHouseworks }) => {
           ))}
       </ul>
 
-      <Link href="/create-housework-page">
-        <div className="flex cursor-pointer mt-3">
-          {/* <<アイコン */}
-          <svg
-            className="w-6 h-6 mr-2"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M11 19l-7-7 7-7m8 14l-7-7 7-7"
-            />
-          </svg>
-          <span>新規Housework</span>
-        </div>
-      </Link>
+      {hasToken && (
+        <Link href="/create-housework-page">
+          <div className="flex cursor-pointer mt-3">
+            {/* <<アイコン */}
+            <svg
+              className="w-6 h-6 mr-2"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M11 19l-7-7 7-7m8 14l-7-7 7-7"
+              />
+            </svg>
+            <span>新規Housework</span>
+          </div>
+        </Link>
+      )}
     </Layout>
   )
 }

--- a/pages/houseworks/[id].tsx
+++ b/pages/houseworks/[id].tsx
@@ -18,7 +18,7 @@ const fetcher = async (url: string) =>
       Authorization: `JWT ${cookie.get('access_token')}`,
     },
   }).then((res) => res.json())
-const apiUrl = `${process.env.NEXT_PUBLIC_RESTAPI_URL}api/houseworks/`
+const apiUrl = `${process.env.NEXT_PUBLIC_RESTAPI_URL}api/detail-housework/`
 
 interface STATICPROPS {
   id: string


### PR DESCRIPTION
・housework-detail画面を参照する場合は/housework/<id>ではなく、/detail-housework/<id>のエンドポイントにアクセスする。

・Create, Delete, Update機能はcookieからトークン取得できない場合、ボタン・リンクを非表示にする

（上記更新とあわせてテストコード更新・追加）