### PR TITLE
KA-20 useSWRでCategoryDropdownをリファクタリング

### DIFF
--- a/__tests__/CategoryDropdown.test.tsx
+++ b/__tests__/CategoryDropdown.test.tsx
@@ -1,0 +1,57 @@
+import '@testing-library/jest-dom/extend-expect'
+import { render, screen, cleanup } from '@testing-library/react'
+import { initTestHelpers } from 'next-page-tester'
+import { rest } from 'msw'
+import { setupServer } from 'msw/node'
+import CategoryDropdown from '../components/CategoryDropdown'
+import userEvent from '@testing-library/user-event'
+import StateContextProvider from '../context/StateContext'
+import { SWRConfig } from 'swr'
+
+initTestHelpers()
+
+const handlers = [
+  rest.get(
+    `${process.env.NEXT_PUBLIC_RESTAPI_URL}api/list-category/`,
+    (req, res, ctx) => {
+      return res(
+        ctx.status(200),
+        ctx.json([
+          { id: 1, category_name: '衣' },
+          { id: 2, category_name: '食' },
+          { id: 3, category_name: '住' },
+        ])
+      )
+    }
+  ),
+]
+const server = setupServer(...handlers)
+
+beforeAll(() => {
+  server.listen()
+})
+afterEach(() => {
+  server.resetHandlers()
+  cleanup()
+  document.cookie =
+    'access_token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;'
+})
+afterAll(() => {
+  server.close()
+})
+
+describe('Categoryドロップダウンコンポーネントの単体テスト', () => {
+  it('APIから取得したCategoryデータリストをもとに、プルダウンがレンダリングされる事', async () => {
+    render(
+      <SWRConfig value={{ dedupingInterval: 0 }}>
+        <CategoryDropdown />
+      </SWRConfig>,
+      { wrapper: StateContextProvider }
+    )
+    await screen.findByText('衣')
+    userEvent.selectOptions(screen.getByRole('combobox'), ['1'])
+    expect(screen.getByRole('option', { name: '衣' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: '食' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: '住' })).toBeInTheDocument()
+  })
+})

--- a/__tests__/HouseworkDetail.test.tsx
+++ b/__tests__/HouseworkDetail.test.tsx
@@ -165,7 +165,8 @@ describe(`housework/[id].js test`, () => {
     })
     render(page)
     expect(await screen.findByText('Housework Detail')).toBeInTheDocument()
-    // expect(screen.getByText('衣')).toBeInTheDocument()
+    await screen.findByText('衣')
+    expect(screen.getByRole('option', { name: '衣' })).toBeInTheDocument()
     expect(screen.getByDisplayValue('dummy data 1')).toBeInTheDocument()
     expect(
       screen.getByDisplayValue('mock api request data 1')
@@ -178,7 +179,8 @@ describe(`housework/[id].js test`, () => {
     })
     render(page)
     expect(await screen.findByText('Housework Detail')).toBeInTheDocument()
-    // expect(screen.getByText('食')).toBeInTheDocument()
+    await screen.findByText('食')
+    expect(screen.getByRole('option', { name: '食' })).toBeInTheDocument()
     expect(screen.getByDisplayValue('dummy data 2')).toBeInTheDocument()
     expect(
       screen.getByDisplayValue('mock api request data 2')

--- a/components/CategoryDropdown.tsx
+++ b/components/CategoryDropdown.tsx
@@ -1,26 +1,26 @@
-import { useContext, useEffect, useState } from 'react'
+import { useContext } from 'react'
 import { CATEGORY } from '../types/Types'
 import { StateContext } from '../context/StateContext'
-import { getAllCategoryData } from '../lib/category'
+import useSWR from 'swr'
+import fetch from 'node-fetch'
 
 const CategoryDropdown: React.FC = () => {
   const { selectedHousework, setSelectedHousework } = useContext(StateContext)
-  const [categoryList, setCategoryList] = useState<CATEGORY[]>([])
 
-  useEffect(() => {
-    // let abortCtrl = new AbortController()
-    getAllCategoryData()
-      .then((res) => setCategoryList(res))
-      .catch((error) => console.error(error))
-    // return () => {
-    //   abortCtrl.abort()
-    // }
-  }, [])
+  const fetcher = async (url: string): Promise<CATEGORY[]> =>
+    await fetch(url).then((res) => res.json())
 
+  const { data, error } = useSWR(
+    `${process.env.NEXT_PUBLIC_RESTAPI_URL}api/list-category/`,
+    fetcher
+  )
   // categoryListから引数のｉｄに一致するcategoryデータを検索し該当データを返す
-  const findCategory = (id: string) => {
-    return categoryList.find((category) => category.id.toString() === id)
+  const findCategory = (id: string): CATEGORY => {
+    return data.find((category) => category.id.toString() === id)
   }
+
+  if (error) return <div>failed to load</div>
+  if (!data) return <div>loading...</div>
 
   return (
     <div className="pl-4 py-4 mb-3 w-16 text-lg border rounded-md border-indigo-500 bg-purple-50">
@@ -34,7 +34,7 @@ const CategoryDropdown: React.FC = () => {
           })
         }
       >
-        {categoryList.map((category) => (
+        {data.map((category) => (
           <option key={category.id} value={category.id}>
             {category.category_name}
           </option>

--- a/lib/category.ts
+++ b/lib/category.ts
@@ -1,5 +1,4 @@
 import fetch from 'node-fetch'
-import { CATEGORY } from '../types/Types'
 
 export const getAllCategoryData = async () => {
   const res = await fetch(


### PR DESCRIPTION
CategoryDropdownについてリファクタリング

- APIへのfetchにuseSWRを導入しerror, loadingのハンドリングを追加
- テスト時のfetchのfailを解消（import fetch from 'node-fetch'）
- CategoryDropdownのコンポーネントテストを作成。HouseworkDetailのテスト更新。