### PR TITLE
KA-38-user-dropdownコンポーネント単体テスト実装

### DIFF
--- a/__tests__/components/CategoryDropdown.test.tsx
+++ b/__tests__/components/CategoryDropdown.test.tsx
@@ -6,6 +6,7 @@ import { setupServer } from 'msw/node'
 import CategoryDropdown from '../../components/CategoryDropdown'
 import userEvent from '@testing-library/user-event'
 import StateContextProvider from '../../context/StateContext'
+import TaskContextProvider from '../../context/TaskContext'
 import { SWRConfig } from 'swr'
 
 initTestHelpers()
@@ -40,13 +41,29 @@ afterAll(() => {
   server.close()
 })
 
-describe('Categoryドロップダウンコンポーネントの単体テスト', () => {
+describe('Categoryドロップダウンコンポーネントの単体テスト(stateContext使用時)', () => {
   it('APIから取得したCategoryデータリストをもとに、プルダウンがレンダリングされる事', async () => {
     render(
       <SWRConfig value={{ dedupingInterval: 0 }}>
         <CategoryDropdown context={'housework'} />
       </SWRConfig>,
       { wrapper: StateContextProvider }
+    )
+    await screen.findByText('衣')
+    userEvent.selectOptions(screen.getByRole('combobox'), ['1'])
+    expect(screen.getByRole('option', { name: '衣' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: '食' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: '住' })).toBeInTheDocument()
+  })
+})
+
+describe('Categoryドロップダウンコンポーネントの単体テスト(taskContext使用時)', () => {
+  it('APIから取得したCategoryデータリストをもとに、プルダウンがレンダリングされる事', async () => {
+    render(
+      <SWRConfig value={{ dedupingInterval: 0 }}>
+        <CategoryDropdown context={'task'} />
+      </SWRConfig>,
+      { wrapper: TaskContextProvider }
     )
     await screen.findByText('衣')
     userEvent.selectOptions(screen.getByRole('combobox'), ['1'])

--- a/__tests__/components/UserDropdown.test.tsx
+++ b/__tests__/components/UserDropdown.test.tsx
@@ -1,0 +1,73 @@
+import '@testing-library/jest-dom/extend-expect'
+import { render, screen, cleanup } from '@testing-library/react'
+import { initTestHelpers } from 'next-page-tester'
+import { rest } from 'msw'
+import { setupServer } from 'msw/node'
+import UserDropdown from '../../components/UserDropdown'
+import StateContextProvider from '../../context/StateContext'
+import TaskContextProvider from '../../context/TaskContext'
+import { SWRConfig } from 'swr'
+import userEvent from '@testing-library/user-event'
+
+initTestHelpers()
+
+const handlers = [
+  rest.get(
+    `${process.env.NEXT_PUBLIC_RESTAPI_URL}api/list-user/`,
+    (req, res, ctx) => {
+      return res(
+        ctx.status(200),
+        ctx.json([
+          { id: 1, username: 'Takuya' },
+          { id: 2, username: 'Narumi' },
+        ])
+      )
+    }
+  ),
+]
+const server = setupServer(...handlers)
+
+beforeAll(() => {
+  server.listen()
+})
+afterEach(() => {
+  server.resetHandlers()
+  cleanup()
+  document.cookie =
+    'access_token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;'
+})
+afterAll(() => {
+  server.close()
+})
+
+describe('Userドロップダウンコンポーネントの単体テスト(stateContext使用時)', () => {
+  it('APIから取得したUserデータリストをもとに、プルダウンがレンダリングされる事', async () => {
+    render(
+      <SWRConfig value={{ dedupingInterval: 0 }}>
+        <UserDropdown context={'housework'} />
+      </SWRConfig>,
+      { wrapper: StateContextProvider }
+    )
+
+    await screen.findByText('ユーザを選択してください')
+    userEvent.selectOptions(screen.getByRole('combobox'), ['1'])
+    expect(screen.getByRole('option', { name: 'Takuya' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Narumi' })).toBeInTheDocument()
+  })
+})
+
+describe('Userドロップダウンコンポーネントの単体テスト(taskContext使用時)', () => {
+  it('APIから取得したUserデータリストをもとに、プルダウンがレンダリングされる事', async () => {
+    render(
+      <SWRConfig value={{ dedupingInterval: 0 }}>
+        <UserDropdown context={'task'} />
+      </SWRConfig>,
+      { wrapper: TaskContextProvider }
+    )
+
+    await screen.findByText('ユーザを選択してください')
+    userEvent.selectOptions(screen.getByRole('combobox'), ['1'])
+    expect(screen.getByRole('option', { name: 'Takuya' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Narumi' })).toBeInTheDocument()
+  })
+})

--- a/__tests__/components/UserDropdown.test.tsx
+++ b/__tests__/components/UserDropdown.test.tsx
@@ -49,7 +49,7 @@ describe('Userドロップダウンコンポーネントの単体テスト(state
       { wrapper: StateContextProvider }
     )
 
-    await screen.findByText('ユーザを選択してください')
+    await screen.findByText('--ユーザを選択してください--')
     userEvent.selectOptions(screen.getByRole('combobox'), ['1'])
     expect(screen.getByRole('option', { name: 'Takuya' })).toBeInTheDocument()
     expect(screen.getByRole('option', { name: 'Narumi' })).toBeInTheDocument()
@@ -65,7 +65,7 @@ describe('Userドロップダウンコンポーネントの単体テスト(taskC
       { wrapper: TaskContextProvider }
     )
 
-    await screen.findByText('ユーザを選択してください')
+    await screen.findByText('--ユーザを選択してください--')
     userEvent.selectOptions(screen.getByRole('combobox'), ['1'])
     expect(screen.getByRole('option', { name: 'Takuya' })).toBeInTheDocument()
     expect(screen.getByRole('option', { name: 'Narumi' })).toBeInTheDocument()

--- a/components/UserDropdown.tsx
+++ b/components/UserDropdown.tsx
@@ -1,5 +1,79 @@
-const UserDropdown = () => {
-  return <div>UserDropdown</div>
+import { useContext } from 'react'
+import useSWR from 'swr'
+import { StateContext } from '../context/StateContext'
+import { TaskContext } from '../context/TaskContext'
+import { USER } from '../types/Types'
+import fetch from 'node-fetch'
+
+interface props {
+  context: string
+}
+const UserDropdown: React.FC<props> = ({ context }) => {
+  const { selectedHousework, setSelectedHousework } = useContext(StateContext)
+  const { selectedTask, setSelectedTask } = useContext(TaskContext)
+
+  const fetcher = async (url: string): Promise<USER[]> =>
+    await fetch(url).then((res) => res.json())
+
+  const { data, error } = useSWR(
+    `${process.env.NEXT_PUBLIC_RESTAPI_URL}api/list-user/`,
+    fetcher
+  )
+  if (error) return <div>failed to load</div>
+  if (!data) return <div>loading...</div>
+
+  const findUser = (id: string): USER => {
+    return data.find((user) => user.id.toString() === id)
+  }
+
+  if (context === 'housework') {
+    return (
+      <div>
+        <select
+          className="bg-transparent"
+          value={selectedHousework.create_user['id']}
+          onChange={(e) =>
+            setSelectedHousework({
+              ...selectedHousework,
+              create_user: findUser(e.target.value),
+            })
+          }
+        >
+          <option value="">--ユーザを選択してください--</option>
+          {data.map((user) => (
+            <option key={user.id} value={user.id}>
+              {user.username}
+            </option>
+          ))}
+        </select>
+      </div>
+    )
+  } else if (context === 'task') {
+    return (
+      <div>
+        <select
+          className="bg-transparent"
+          value={selectedTask.assigned_user['id']}
+          onChange={(e) =>
+            setSelectedTask({
+              ...selectedTask,
+              assigned_user: findUser(e.target.value),
+            })
+          }
+        >
+          <option value="">--ユーザを選択してください--</option>
+
+          {data.map((user) => (
+            <option key={user.id} value={user.id}>
+              {user.username}
+            </option>
+          ))}
+        </select>
+      </div>
+    )
+  } else {
+    return <div>props invalid</div>
+  }
 }
 
 export default UserDropdown

--- a/components/UserDropdown.tsx
+++ b/components/UserDropdown.tsx
@@ -1,0 +1,5 @@
+const UserDropdown = () => {
+  return <div>UserDropdown</div>
+}
+
+export default UserDropdown

--- a/context/TaskContext.tsx
+++ b/context/TaskContext.tsx
@@ -31,3 +31,4 @@ export const TaskContextProvider: React.FC = ({ children }) => {
     </TaskContext.Provider>
   )
 }
+export default TaskContextProvider


### PR DESCRIPTION
UserDropdown.tsxのコンポーネントを実装
・APIからUser一覧を取得し動的にOptionを生成しドロップダウンに表示する
・option選択時にContextにもつTask, Houseworkのuser情報を更新