### PR TITLE
KA-32-taskデータの更新フォーム作成

### DIFF
--- a/__tests__/components/TaskComponent.test.tsx
+++ b/__tests__/components/TaskComponent.test.tsx
@@ -25,7 +25,7 @@ describe('Task component with given prop', () => {
   })
 
   it('Should render correctly with given props value', () => {
-    render(<Task {...dummyProps} />)
+    render(<Task task={dummyProps} />)
     expect(screen.getByText(dummyProps.task_name)).toBeInTheDocument()
     expect(screen.getByText(dummyProps.scheduled_date)).toBeInTheDocument()
     expect(

--- a/__tests__/components/TaskForm.test.tsx
+++ b/__tests__/components/TaskForm.test.tsx
@@ -17,6 +17,12 @@ const handlers = [
       return res(ctx.status(201))
     }
   ),
+  rest.put(
+    `${process.env.NEXT_PUBLIC_RESTAPI_URL}api/tasks/:id`,
+    (req, res, ctx) => {
+      return res(ctx.status(200))
+    }
+  ),
   rest.get(
     `${process.env.NEXT_PUBLIC_RESTAPI_URL}api/list-category/`,
     (req, res, ctx) => {
@@ -60,8 +66,23 @@ describe('Task登録フォームのコンポーネント単体テスト', () => 
       username: 'Takuya',
     },
     scheduled_date: '2022-06-12',
-    result_date: undefined,
-    result_time: undefined,
+    result_date: '',
+    result_time: 0,
+  }
+  const updateTask = {
+    task_name: 'お風呂掃除',
+    category: {
+      id: 3,
+      category_name: '住',
+    },
+    status: '完了',
+    assigned_user: {
+      id: 3,
+      username: 'Narumi',
+    },
+    scheduled_date: '2022-06-12',
+    result_date: '2022-06-12',
+    result_time: 10,
   }
 
   it('フォーム入力欄にTask内容を入力して、登録ボタン実行が成功する事', async () => {
@@ -147,6 +168,87 @@ describe('Task登録フォームのコンポーネント単体テスト', () => 
 
     expect(
       await screen.findByText('タスクの登録に失敗しました')
+    ).toBeInTheDocument()
+  })
+  it('フォームの入力内容を変更し、更新ボタン実行が成功する事', async () => {
+    document.cookie = 'access_token=123xyz'
+    render(
+      <SWRConfig value={{ dedupingInterval: 0 }}>
+        <TaskForm />
+      </SWRConfig>,
+      { wrapper: TaskContextProvider }
+    )
+    // フォーム入力前は更新Buttonが非活性になっている事
+    const createButton = screen.getByText('更新')
+    expect(createButton).toBeDisabled()
+
+    // 各入力フォームに入力できる事
+    const taskInput = screen.getByPlaceholderText('タスク名')
+    userEvent.clear(taskInput)
+    userEvent.type(taskInput, updateTask.task_name)
+    expect(screen.getByDisplayValue(updateTask.task_name)).toBeInTheDocument()
+
+    // Categoryドロップダウンのfetchができるまで待つ
+    await screen.findByText('衣')
+    userEvent.selectOptions(screen.getByDisplayValue('衣'), ['2'])
+    expect(
+      screen.getByDisplayValue(updateTask.category['category_name'])
+    ).toBeInTheDocument()
+
+    // 担当者を変更
+    const inputUser = await screen.findByText(/担当者/)
+    userEvent.selectOptions(
+      inputUser,
+      updateTask.assigned_user['id'].toString()
+    )
+
+    // ステータスの入力値をクリアして”完了”にする
+    const inputStatus = screen.getByPlaceholderText('ステータス')
+    userEvent.clear(inputStatus)
+    userEvent.type(inputStatus, updateTask.status)
+    expect(screen.getByDisplayValue(updateTask.status)).toBeInTheDocument()
+
+    // 実績日を入力
+    fireEvent.change(screen.getByPlaceholderText('実績日'), {
+      target: { value: updateTask.scheduled_date },
+    })
+    expect(screen.getByDisplayValue(updateTask.result_date)).toBeInTheDocument()
+
+    // 実績時間を入力
+    const inputResultTime = screen.getByPlaceholderText('実績時間')
+    userEvent.clear(inputResultTime)
+    userEvent.type(inputResultTime, updateTask.result_time.toString())
+
+    // 更新Buttonが活性化され、更新実行後に更新成功メッセージが表示される事
+    const updateButton = screen.getByText('更新')
+    expect(updateButton).toBeEnabled()
+    userEvent.click(updateButton)
+    expect(await screen.findByText('タスクを更新しました')).toBeInTheDocument()
+  })
+
+  it('バックエンドのサーバエラー時、更新処理に失敗しその旨メッセージが表示される事', async () => {
+    document.cookie = 'access_token=123xyx'
+    server.use(
+      rest.put(
+        `${process.env.NEXT_PUBLIC_RESTAPI_URL}api/tasks/:id`,
+        (req, res, ctx) => {
+          return res(ctx.status(503))
+        }
+      )
+    )
+
+    // ステータスの入力値をクリアして”完了”にする
+    const inputStatus = screen.getByPlaceholderText('ステータス')
+    userEvent.clear(inputStatus)
+    userEvent.type(inputStatus, updateTask.status)
+    expect(screen.getByDisplayValue(updateTask.status)).toBeInTheDocument()
+
+    // 更新Buttonが活性化され、更新実行後に更新失敗メッセージが表示される事
+    const updateButton = screen.getByText('更新')
+    expect(updateButton).toBeEnabled()
+    userEvent.click(updateButton)
+    expect(
+      await screen.findByText('タスクの更新に失敗しました')
     ).toBeInTheDocument()
   })
 })

--- a/__tests__/components/TaskForm.test.tsx
+++ b/__tests__/components/TaskForm.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, cleanup } from '@testing-library/react'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 import userEvent from '@testing-library/user-event'
 import { initTestHelpers } from 'next-page-tester'
@@ -83,16 +83,20 @@ describe('Task登録フォームのコンポーネント単体テスト', () => 
 
     // Categoryドロップダウンのfetchができるまで待つ
     await screen.findByText('衣')
-    userEvent.selectOptions(screen.getByRole('combobox'), ['1'])
+    userEvent.selectOptions(screen.getByDisplayValue('衣'), ['1'])
+
+    userEvent.clear(screen.getByPlaceholderText('ステータス'))
     userEvent.type(screen.getByPlaceholderText('ステータス'), inputTask.status)
-    // userEvent.type(
-    //   screen.getByPlaceholderText('担当者'),
-    //   inputTask.assigned_user['id'].toString()
-    // )
-    // userEvent.type(
-    //   screen.getByPlaceholderText('対応予定日'),
-    //   inputTask.scheduled_date
-    // )
+
+    await screen.findByText(/担当者/)
+    userEvent.selectOptions(
+      screen.getByDisplayValue(/担当者/),
+      inputTask.assigned_user['id'].toString()
+    )
+
+    fireEvent.change(screen.getByPlaceholderText('対応予定日'), {
+      target: { value: inputTask.scheduled_date },
+    })
 
     // 正しいInputデータ入力後、登録buttonが活性化されクリックすると登録が完了した旨メッセージが表示される事
     expect(createButton).toBeEnabled()
@@ -115,20 +119,26 @@ describe('Task登録フォームのコンポーネント単体テスト', () => 
 
     render(<TaskForm />, { wrapper: TaskContextProvider })
 
+    // 各入力フォームに入力できる事
     userEvent.type(screen.getByPlaceholderText('タスク名'), inputTask.task_name)
+    expect(screen.getByDisplayValue(inputTask.task_name)).toBeInTheDocument()
 
+    // Categoryドロップダウンのfetchができるまで待つ
     await screen.findByText('衣')
-    userEvent.selectOptions(screen.getByRole('combobox'), ['1'])
+    userEvent.selectOptions(screen.getByDisplayValue('衣'), ['1'])
 
+    userEvent.clear(screen.getByPlaceholderText('ステータス'))
     userEvent.type(screen.getByPlaceholderText('ステータス'), inputTask.status)
-    // userEvent.type(
-    //   screen.getByPlaceholderText('担当者'),
-    //   inputTask.assigned_user['id'].toString()
-    // )
-    // userEvent.type(
-    //   screen.getByPlaceholderText('対応予定日'),
-    //   inputTask.scheduled_date
-    // )
+
+    await screen.findByText(/担当者/)
+    userEvent.selectOptions(
+      screen.getByDisplayValue(/担当者/),
+      inputTask.assigned_user['id'].toString()
+    )
+
+    fireEvent.change(screen.getByPlaceholderText('対応予定日'), {
+      target: { value: inputTask.scheduled_date },
+    })
 
     // 登録Buttonクリック後、登録失敗した場合その旨メッセージが表示される事
     const createButton = screen.getByText('登録')

--- a/__tests__/components/TaskForm.test.tsx
+++ b/__tests__/components/TaskForm.test.tsx
@@ -70,6 +70,7 @@ describe('Task登録フォームのコンポーネント単体テスト', () => 
     result_time: 0,
   }
   const updateTask = {
+    id: 1,
     task_name: 'お風呂掃除',
     category: {
       id: 3,
@@ -168,87 +169,6 @@ describe('Task登録フォームのコンポーネント単体テスト', () => 
 
     expect(
       await screen.findByText('タスクの登録に失敗しました')
-    ).toBeInTheDocument()
-  })
-  it('フォームの入力内容を変更し、更新ボタン実行が成功する事', async () => {
-    document.cookie = 'access_token=123xyz'
-    render(
-      <SWRConfig value={{ dedupingInterval: 0 }}>
-        <TaskForm />
-      </SWRConfig>,
-      { wrapper: TaskContextProvider }
-    )
-    // フォーム入力前は更新Buttonが非活性になっている事
-    const createButton = screen.getByText('更新')
-    expect(createButton).toBeDisabled()
-
-    // 各入力フォームに入力できる事
-    const taskInput = screen.getByPlaceholderText('タスク名')
-    userEvent.clear(taskInput)
-    userEvent.type(taskInput, updateTask.task_name)
-    expect(screen.getByDisplayValue(updateTask.task_name)).toBeInTheDocument()
-
-    // Categoryドロップダウンのfetchができるまで待つ
-    await screen.findByText('衣')
-    userEvent.selectOptions(screen.getByDisplayValue('衣'), ['2'])
-    expect(
-      screen.getByDisplayValue(updateTask.category['category_name'])
-    ).toBeInTheDocument()
-
-    // 担当者を変更
-    const inputUser = await screen.findByText(/担当者/)
-    userEvent.selectOptions(
-      inputUser,
-      updateTask.assigned_user['id'].toString()
-    )
-
-    // ステータスの入力値をクリアして”完了”にする
-    const inputStatus = screen.getByPlaceholderText('ステータス')
-    userEvent.clear(inputStatus)
-    userEvent.type(inputStatus, updateTask.status)
-    expect(screen.getByDisplayValue(updateTask.status)).toBeInTheDocument()
-
-    // 実績日を入力
-    fireEvent.change(screen.getByPlaceholderText('実績日'), {
-      target: { value: updateTask.scheduled_date },
-    })
-    expect(screen.getByDisplayValue(updateTask.result_date)).toBeInTheDocument()
-
-    // 実績時間を入力
-    const inputResultTime = screen.getByPlaceholderText('実績時間')
-    userEvent.clear(inputResultTime)
-    userEvent.type(inputResultTime, updateTask.result_time.toString())
-
-    // 更新Buttonが活性化され、更新実行後に更新成功メッセージが表示される事
-    const updateButton = screen.getByText('更新')
-    expect(updateButton).toBeEnabled()
-    userEvent.click(updateButton)
-    expect(await screen.findByText('タスクを更新しました')).toBeInTheDocument()
-  })
-
-  it('バックエンドのサーバエラー時、更新処理に失敗しその旨メッセージが表示される事', async () => {
-    document.cookie = 'access_token=123xyx'
-    server.use(
-      rest.put(
-        `${process.env.NEXT_PUBLIC_RESTAPI_URL}api/tasks/:id`,
-        (req, res, ctx) => {
-          return res(ctx.status(503))
-        }
-      )
-    )
-
-    // ステータスの入力値をクリアして”完了”にする
-    const inputStatus = screen.getByPlaceholderText('ステータス')
-    userEvent.clear(inputStatus)
-    userEvent.type(inputStatus, updateTask.status)
-    expect(screen.getByDisplayValue(updateTask.status)).toBeInTheDocument()
-
-    // 更新Buttonが活性化され、更新実行後に更新失敗メッセージが表示される事
-    const updateButton = screen.getByText('更新')
-    expect(updateButton).toBeEnabled()
-    userEvent.click(updateButton)
-    expect(
-      await screen.findByText('タスクの更新に失敗しました')
     ).toBeInTheDocument()
   })
 })

--- a/__tests__/components/UserDropdown.test.tsx
+++ b/__tests__/components/UserDropdown.test.tsx
@@ -49,7 +49,7 @@ describe('Userドロップダウンコンポーネントの単体テスト(state
       { wrapper: StateContextProvider }
     )
 
-    await screen.findByText('--ユーザを選択してください--')
+    await screen.findByText('--担当者を選択してください--')
     userEvent.selectOptions(screen.getByRole('combobox'), ['1'])
     expect(screen.getByRole('option', { name: 'Takuya' })).toBeInTheDocument()
     expect(screen.getByRole('option', { name: 'Narumi' })).toBeInTheDocument()
@@ -65,7 +65,7 @@ describe('Userドロップダウンコンポーネントの単体テスト(taskC
       { wrapper: TaskContextProvider }
     )
 
-    await screen.findByText('--ユーザを選択してください--')
+    await screen.findByText('--担当者を選択してください--')
     userEvent.selectOptions(screen.getByRole('combobox'), ['1'])
     expect(screen.getByRole('option', { name: 'Takuya' })).toBeInTheDocument()
     expect(screen.getByRole('option', { name: 'Narumi' })).toBeInTheDocument()

--- a/__tests__/pages/CreateTaskPage.test.tsx
+++ b/__tests__/pages/CreateTaskPage.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom/extend-expect'
-import { render, screen, cleanup } from '@testing-library/react'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
 import { getPage } from 'next-page-tester'
 import { initTestHelpers } from 'next-page-tester'
 import { rest } from 'msw'
@@ -70,22 +70,24 @@ describe('create-task-page.tsxのページテスト', () => {
     // 各入力フォームに入力できる事
     userEvent.type(screen.getByPlaceholderText('タスク名'), inputTask.task_name)
     expect(screen.getByDisplayValue(inputTask.task_name)).toBeInTheDocument()
-    // ).toBe(inputTask.task_name)
 
     // Categoryドロップダウンのfetchができるまで待つ
     await screen.findByText('衣')
-    userEvent.selectOptions(screen.getByRole('combobox'), ['1'])
+    userEvent.selectOptions(screen.getByDisplayValue('衣'), ['1'])
 
-    // userEvent.type(screen.getByPlaceholderText('ステータス'), inputTask.status)
+    userEvent.clear(screen.getByPlaceholderText('ステータス'))
+    userEvent.type(screen.getByPlaceholderText('ステータス'), inputTask.status)
     expect(screen.getByDisplayValue(inputTask.status)).toBeInTheDocument()
-    // userEvent.type(
-    //   screen.getByPlaceholderText('担当者'),
-    //   inputTask.assigned_user['id'].toString()
-    // )
-    // userEvent.type(
-    //   screen.getByPlaceholderText('対応予定日'),
-    //   inputTask.scheduled_date
-    // )
+
+    await screen.findByText(/担当者/)
+    userEvent.selectOptions(
+      screen.getByDisplayValue(/担当者/),
+      inputTask.assigned_user['id'].toString()
+    )
+
+    fireEvent.change(screen.getByPlaceholderText('対応予定日'), {
+      target: { value: inputTask.scheduled_date },
+    })
 
     // 正しいInputデータ入力後、登録buttonが活性化されクリックすると登録が完了した旨メッセージが表示される事
     const createButton = screen.getByText('登録')

--- a/__tests__/pages/TodoPage.test.tsx
+++ b/__tests__/pages/TodoPage.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom/extend-expect'
-import { render, screen, cleanup } from '@testing-library/react'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
 import { getPage } from 'next-page-tester'
 import { initTestHelpers } from 'next-page-tester'
 import { SWRConfig } from 'swr'
@@ -7,6 +7,7 @@ import { rest } from 'msw'
 import { setupServer } from 'msw/node'
 import { TASK } from '../../types/Types'
 import TodoList from '../../pages/todo-page'
+import userEvent from '@testing-library/user-event'
 
 initTestHelpers()
 
@@ -27,7 +28,7 @@ const handlers = [
             status: '未着手',
             assigned_user: {
               id: 1,
-              username: 'Dummy User 1',
+              username: 'Takuya',
             },
             scheduled_date: '2022/04/26',
             result_date: '2022/04/27',
@@ -43,7 +44,7 @@ const handlers = [
             status: '完了',
             assigned_user: {
               id: 2,
-              username: 'Dummy User 2',
+              username: 'Narumi',
             },
             scheduled_date: '2022/06/08',
             result_date: '2022/06/08',
@@ -51,6 +52,24 @@ const handlers = [
           },
         ])
       )
+    }
+  ),
+  rest.get(
+    `${process.env.NEXT_PUBLIC_RESTAPI_URL}api/list-user/`,
+    (req, res, ctx) => {
+      return res(
+        ctx.status(200),
+        ctx.json([
+          { id: 1, username: 'Takuya' },
+          { id: 2, username: 'Narumi' },
+        ])
+      )
+    }
+  ),
+  rest.put(
+    `${process.env.NEXT_PUBLIC_RESTAPI_URL}api/tasks/:id`,
+    (req, res, ctx) => {
+      return res(ctx.status(200))
     }
   ),
 ]
@@ -94,6 +113,108 @@ describe(`Task-page test`, () => {
     render(page)
     expect(await screen.findByText('ToDo Page')).toBeInTheDocument()
     expect(screen.queryByText('新規Task')).toBeNull()
+  })
+
+  const updateTask = {
+    task_name: 'お風呂掃除',
+    category: {
+      id: 3,
+      category_name: '住',
+    },
+    status: '完了',
+    assigned_user: {
+      id: 2,
+      username: 'Narumi',
+    },
+    scheduled_date: '2022-06-12',
+    result_date: '2022-06-12',
+    result_time: 10,
+  }
+  it('フォームの入力内容を変更し、更新ボタン実行が成功する事', async () => {
+    document.cookie = 'access_token=123xyz'
+    const { page } = await getPage({ route: '/todo-page' })
+    render(page)
+    expect(await screen.findByText('ToDo Page')).toBeInTheDocument()
+
+    // TaskをクリックするとModalが表示される事
+    userEvent.click(screen.getByText('dummy task 1'))
+    expect(await screen.findByText('Task更新')).toBeInTheDocument()
+
+    // 各入力フォームに入力できる事
+    const taskInput = screen.getByPlaceholderText('タスク名')
+    userEvent.clear(taskInput)
+    userEvent.type(taskInput, updateTask.task_name)
+    expect(screen.getByDisplayValue(updateTask.task_name)).toBeInTheDocument()
+
+    // Categoryドロップダウンのfetchができるまで待つ
+    await screen.findByText('衣')
+    userEvent.selectOptions(screen.getByDisplayValue('衣'), ['3'])
+    expect(
+      screen.getByDisplayValue(updateTask.category['category_name'])
+    ).toBeInTheDocument()
+
+    // 担当者を変更
+    const inputUser = await screen.findByText(/担当者/)
+    expect(screen.getByRole('option', { name: 'Takuya' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Narumi' })).toBeInTheDocument()
+    // userEvent.selectOptions(inputUser, ['2'])
+
+    // ステータスの入力値をクリアして”完了”にする
+    const inputStatus = screen.getByPlaceholderText('ステータス')
+    userEvent.clear(inputStatus)
+    userEvent.type(inputStatus, updateTask.status)
+    expect(screen.getByDisplayValue(updateTask.status)).toBeInTheDocument()
+
+    // 実績日を入力
+    fireEvent.change(screen.getByPlaceholderText('実績日'), {
+      target: { value: updateTask.scheduled_date },
+    })
+    expect(screen.getByDisplayValue(updateTask.result_date)).toBeInTheDocument()
+
+    // 実績時間を入力
+    const inputResultTime = screen.getByPlaceholderText('実績時間')
+    userEvent.clear(inputResultTime)
+    userEvent.type(inputResultTime, updateTask.result_time.toString())
+
+    // 更新Buttonが活性化され、更新実行後に更新成功メッセージが表示される事
+    const updateButton = screen.getByText('更新')
+    expect(updateButton).toBeEnabled()
+    userEvent.click(updateButton)
+    expect(await screen.findByText('タスクを更新しました')).toBeInTheDocument()
+  })
+
+  it('バックエンドのサーバエラー時、更新処理に失敗しその旨メッセージが表示される事', async () => {
+    document.cookie = 'access_token=123xyx'
+    server.use(
+      rest.put(
+        `${process.env.NEXT_PUBLIC_RESTAPI_URL}api/tasks/:id`,
+        (req, res, ctx) => {
+          return res(ctx.status(503))
+        }
+      )
+    )
+    document.cookie = 'access_token=123xyz'
+    const { page } = await getPage({ route: '/todo-page' })
+    render(page)
+    expect(await screen.findByText('ToDo Page')).toBeInTheDocument()
+
+    // TaskをクリックするとModalが表示される事
+    userEvent.click(screen.getByText('dummy task 1'))
+    expect(await screen.findByText('Task更新')).toBeInTheDocument()
+
+    // ステータスの入力値をクリアして”完了”にする
+    const inputStatus = screen.getByPlaceholderText('ステータス')
+    userEvent.clear(inputStatus)
+    userEvent.type(inputStatus, updateTask.status)
+    expect(screen.getByDisplayValue(updateTask.status)).toBeInTheDocument()
+
+    // 更新Buttonが活性化され、更新実行後に更新失敗メッセージが表示される事
+    const updateButton = screen.getByText('更新')
+    expect(updateButton).toBeEnabled()
+    userEvent.click(updateButton)
+    expect(
+      await screen.findByText('タスクの更新に失敗しました')
+    ).toBeInTheDocument()
   })
 })
 

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -1,0 +1,54 @@
+import { useContext } from 'react'
+import { TaskContext } from '../context/TaskContext'
+import TaskForm from './TaskForm'
+import { KeyedMutator } from 'swr'
+import { TASK } from '../types/Types'
+
+interface PROPS {
+  mutate: KeyedMutator<TASK[]>
+}
+
+const Modal: React.FC<PROPS> = ({ mutate }) => {
+  const { showModal, setShowModal } = useContext(TaskContext)
+  const clearModal = () => {
+    mutate()
+    setShowModal(false)
+  }
+  return (
+    <>
+      {showModal ? (
+        <>
+          <div className="justify-center items-center flex overflow-x-hidden overflow-y-auto fixed inset-0 z-50 outline-none focus:outline-none">
+            <div className="relative w-2/5 my-6 mx-auto max-w-3xl">
+              {/*content*/}
+              <div className="border-0 rounded-lg shadow-lg relative flex flex-col w-full bg-white outline-none focus:outline-none">
+                {/*header*/}
+                <div className="flex items-start justify-between p-5 border-b border-solid border-slate-200 rounded-t">
+                  <h3 className="text-2xl font-semibold">Task更新</h3>
+                  <button
+                    className="p-1 ml-auto bg-transparent border-0 text-black float-right text-2xl leading-none font-semibold outline-none focus:outline-none"
+                    onClick={() => clearModal()}
+                  >
+                    <span
+                      className="bg-transparent text-black h-6 w-6 opacity-50
+                     text-2xl block outline-none focus:outline-none"
+                    >
+                      ×
+                    </span>
+                  </button>
+                </div>
+                {/*body*/}
+                <div className="relative p-6 flex-auto">
+                  <TaskForm />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div className="opacity-25 fixed inset-0 z-40 bg-black"></div>
+        </>
+      ) : null}
+    </>
+  )
+}
+
+export default Modal

--- a/components/Task.tsx
+++ b/components/Task.tsx
@@ -1,29 +1,35 @@
 import { TASK } from '../types/Types'
+import { TaskContext } from '../context/TaskContext'
+import { useContext } from 'react'
 
-const Task: React.FC<TASK> = ({
-  task_name,
-  scheduled_date,
-  assigned_user,
-  status,
-}) => {
+interface PROPS {
+  task: TASK
+}
+
+const Task: React.FC<PROPS> = ({ task }) => {
+  const { setSelectedTask, setShowModal } = useContext(TaskContext)
   return (
     <div
       className="shadow-md w-4/5 items-center m-auto
                   mb-3 cursor-pointer border rounded-md border-slate-300"
+      onClick={() => {
+        setSelectedTask(task)
+        setShowModal(true)
+      }}
     >
       <div className="py-2 text-center text-gray-700">
         <span className="text-xl font-semibold border-b border-gray-500">
-          {task_name}
+          {task.task_name}
         </span>
       </div>
       <div className="py-1 text-sm text-gray-700 text-center">
-        担当 <span className="text-lg">{assigned_user['username']}</span>
+        担当 <span className="text-lg">{task.assigned_user['username']}</span>
       </div>
       <div className="py-1 text-sm text-gray-700 text-center">
-        対応予定 <span className="text-lg">{scheduled_date}</span>
+        対応予定 <span className="text-lg">{task.scheduled_date}</span>
       </div>
       <div className="py-1 text-base text-gray-700 text-center">
-        <span>【{status}】</span>
+        <span>【{task.status}】</span>
       </div>
     </div>
   )

--- a/components/TaskForm.tsx
+++ b/components/TaskForm.tsx
@@ -107,7 +107,7 @@ const TaskForm: React.FC = () => {
                 !selectedTask.task_name ||
                 !selectedTask.status ||
                 !selectedTask.scheduled_date ||
-                !selectedTask.assigned_user['username']
+                selectedTask.assigned_user['id'] === 0
               }
               className="text-sm px-2 py-1 mt-2 disabled:opacity-40
               bg-blue-300 hover:bg-blue-400 rounded uppercase"

--- a/components/TaskForm.tsx
+++ b/components/TaskForm.tsx
@@ -11,6 +11,7 @@ const TaskForm: React.FC = () => {
   const { selectedTask, setSelectedTask } = useContext(TaskContext)
   const [hasToken, setHasToken] = useState(false)
   const [message, setMessage] = useState('')
+
   const apiUrl = `${process.env.NEXT_PUBLIC_RESTAPI_URL}api/tasks/`
 
   // Cookieの認証トークン確認
@@ -32,6 +33,8 @@ const TaskForm: React.FC = () => {
           status: selectedTask.status,
           assigned_user: selectedTask.assigned_user['id'],
           scheduled_date: selectedTask.scheduled_date,
+          result_date: selectedTask.result_date,
+          result_time: selectedTask.result_time,
         },
         {
           headers: {
@@ -48,9 +51,39 @@ const TaskForm: React.FC = () => {
     }
   }
 
+  const updateTask = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    try {
+      const res = await axios.put(
+        `${apiUrl}${selectedTask.id}/`,
+        {
+          task_name: selectedTask.task_name,
+          category: selectedTask.category['id'],
+          status: selectedTask.status,
+          assigned_user: selectedTask.assigned_user['id'],
+          scheduled_date: selectedTask.scheduled_date,
+          result_date: selectedTask.result_date,
+          result_time: selectedTask.result_time,
+        },
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `JWT ${cookie.get('access_token')}`,
+          },
+        }
+      )
+      if (res.status === 200) {
+        setMessage('タスクを更新しました')
+      }
+    } catch (error) {
+      setMessage('タスクの更新に失敗しました')
+    }
+  }
+
   return (
-    <section className="p-6 w-4/5 max-w-4xl bg-white rounded-md shadow-md">
-      <form onSubmit={createTask}>
+    <>
+      {/* <section className="p-6 w-4/5 max-w-4xl bg-white rounded-md shadow-md"> */}
+      <form onSubmit={selectedTask.id !== 0 ? updateTask : createTask}>
         <CategoryDropdown context={'task'} />
 
         <input
@@ -99,6 +132,40 @@ const TaskForm: React.FC = () => {
             })
           }
         />
+        {/* 実績日 */}
+        <input
+          className="block text-black text-center w-full px-4 py-2 mb-3 
+          border border-gray-300 rounded-md
+          focus:border-blue-400 focus:ring-blue-300 focus:ring-opacity-40
+          focus:outline-none focus:ring"
+          type="date"
+          placeholder="実績日"
+          value={selectedTask.result_date}
+          onChange={(e) =>
+            setSelectedTask({
+              ...selectedTask,
+              result_date: e.target.value,
+            })
+          }
+        />
+
+        {/* 実績時間 */}
+        <input
+          className="block text-black text-center w-full px-4 py-2 mb-3 
+          border border-gray-300 rounded-md
+          focus:border-blue-400 focus:ring-blue-300 focus:ring-opacity-40
+          focus:outline-none focus:ring"
+          type="number"
+          placeholder="実績時間"
+          value={selectedTask.result_time}
+          onChange={(e) =>
+            setSelectedTask({
+              ...selectedTask,
+              result_time: Number(e.target.value),
+            })
+          }
+        />
+
         <div className="flex justify-center">
           {hasToken && (
             <button
@@ -112,13 +179,14 @@ const TaskForm: React.FC = () => {
               className="text-sm px-2 py-1 mt-2 disabled:opacity-40
               bg-blue-300 hover:bg-blue-400 rounded uppercase"
             >
-              {'登録'}
+              {selectedTask.id !== 0 ? '更新' : '登録'}
             </button>
           )}
         </div>
       </form>
       {message && <p className="mt-5 text-blue-400 text-center">{message}</p>}
-    </section>
+      {/* </section> */}
+    </>
   )
 }
 export default TaskForm

--- a/components/TaskForm.tsx
+++ b/components/TaskForm.tsx
@@ -2,6 +2,7 @@ import { useContext, useState, useEffect } from 'react'
 import { TaskContext } from '../context/TaskContext'
 import Cookie from 'universal-cookie'
 import CategoryDropdown from './CategoryDropdown'
+import UserDropdown from './UserDropdown'
 import axios from 'axios'
 
 const cookie = new Cookie()
@@ -53,7 +54,7 @@ const TaskForm: React.FC = () => {
         <CategoryDropdown context={'task'} />
 
         <input
-          className="block text-black w-full px-4 py-2 mb-3 
+          className="block text-black text-center w-full px-4 py-2 mb-3 
           border border-gray-300 rounded-md
           focus:border-blue-400 focus:ring-blue-300 focus:ring-opacity-40
           focus:outline-none focus:ring"
@@ -65,8 +66,11 @@ const TaskForm: React.FC = () => {
             setSelectedTask({ ...selectedTask, task_name: e.target.value })
           }
         />
+
+        <UserDropdown context={'task'} />
+
         <input
-          className="block text-black w-full px-4 py-2 mb-3 
+          className="block text-black text-center w-full px-4 py-2 mb-3 
                     border border-gray-300 rounded-md
                     focus:border-blue-400 focus:ring-blue-300 focus:ring-opacity-40
                     focus:outline-none focus:ring"
@@ -78,8 +82,9 @@ const TaskForm: React.FC = () => {
             setSelectedTask({ ...selectedTask, status: e.target.value })
           }
         />
+
         <input
-          className="block text-black w-full px-4 py-2 mb-3 
+          className="block text-black text-center w-full px-4 py-2 mb-3 
           border border-gray-300 rounded-md
           focus:border-blue-400 focus:ring-blue-300 focus:ring-opacity-40
           focus:outline-none focus:ring"
@@ -98,8 +103,13 @@ const TaskForm: React.FC = () => {
           {hasToken && (
             <button
               type="submit"
-              disabled={!selectedTask.task_name || !selectedTask.status}
-              className="text-sm px-2 py-1 mt-2
+              disabled={
+                !selectedTask.task_name ||
+                !selectedTask.status ||
+                !selectedTask.scheduled_date ||
+                !selectedTask.assigned_user['username']
+              }
+              className="text-sm px-2 py-1 mt-2 disabled:opacity-40
               bg-blue-300 hover:bg-blue-400 rounded uppercase"
             >
               {'登録'}

--- a/components/UserDropdown.tsx
+++ b/components/UserDropdown.tsx
@@ -30,7 +30,7 @@ const UserDropdown: React.FC<props> = ({ context }) => {
     return (
       <div>
         <select
-          className="bg-transparent"
+          required
           value={selectedHousework.create_user['id']}
           onChange={(e) =>
             setSelectedHousework({
@@ -39,7 +39,10 @@ const UserDropdown: React.FC<props> = ({ context }) => {
             })
           }
         >
-          <option value="">--ユーザを選択してください--</option>
+          <option value="0" disabled>
+            --担当者を選択してください--
+          </option>
+
           {data.map((user) => (
             <option key={user.id} value={user.id}>
               {user.username}
@@ -52,7 +55,11 @@ const UserDropdown: React.FC<props> = ({ context }) => {
     return (
       <div>
         <select
-          className="bg-transparent"
+          className="block text-black text-center w-full px-4 py-2 mb-3
+                     border border-gray-300 rounded-md
+                    focus:border-blue-400 focus:ring-blue-300 focus:ring-opacity-40
+                    focus:outline-none focus:ring"
+          required
           value={selectedTask.assigned_user['id']}
           onChange={(e) =>
             setSelectedTask({
@@ -61,7 +68,9 @@ const UserDropdown: React.FC<props> = ({ context }) => {
             })
           }
         >
-          <option value="">--ユーザを選択してください--</option>
+          <option value="0" disabled>
+            --担当者を選択してください--
+          </option>
 
           {data.map((user) => (
             <option key={user.id} value={user.id}>

--- a/context/TaskContext.tsx
+++ b/context/TaskContext.tsx
@@ -18,8 +18,8 @@ export const TaskContextProvider: React.FC = ({ children }) => {
     },
     status: '未着手',
     assigned_user: {
-      id: 2,
-      username: 'Takuya',
+      id: 0,
+      username: undefined,
     },
     scheduled_date: undefined,
     result_date: undefined,

--- a/context/TaskContext.tsx
+++ b/context/TaskContext.tsx
@@ -19,11 +19,11 @@ export const TaskContextProvider: React.FC = ({ children }) => {
     status: '未着手',
     assigned_user: {
       id: 0,
-      username: undefined,
+      username: '未設定',
     },
-    scheduled_date: undefined,
-    result_date: undefined,
-    result_time: undefined,
+    scheduled_date: '',
+    result_date: '',
+    result_time: 0,
   })
   return (
     <TaskContext.Provider value={{ selectedTask, setSelectedTask }}>

--- a/context/TaskContext.tsx
+++ b/context/TaskContext.tsx
@@ -5,6 +5,8 @@ export const TaskContext = createContext(
   {} as {
     selectedTask: TASK
     setSelectedTask: React.Dispatch<React.SetStateAction<TASK>>
+    showModal: Boolean
+    setShowModal: React.Dispatch<React.SetStateAction<boolean>>
   }
 )
 
@@ -22,11 +24,15 @@ export const TaskContextProvider: React.FC = ({ children }) => {
       username: '未設定',
     },
     scheduled_date: '',
-    result_date: '',
+    result_date: undefined,
     result_time: 0,
   })
+  const [showModal, setShowModal] = useState(false)
+
   return (
-    <TaskContext.Provider value={{ selectedTask, setSelectedTask }}>
+    <TaskContext.Provider
+      value={{ selectedTask, setSelectedTask, showModal, setShowModal }}
+    >
       {children}
     </TaskContext.Provider>
   )

--- a/mocks/handlers.js
+++ b/mocks/handlers.js
@@ -15,11 +15,11 @@ export const handlers = [
             },
             status: '未着手',
             assigned_user: {
-              'id': 1,
+              'id': 3,
               'username': 'Narumi'
             },
-            scheduled_date: '2022/06/10',
-            result_date: '2022/06/10',
+            scheduled_date: '2022-06-10',
+            result_date: '2022-06-11',
             result_time: 30,
           },
           {
@@ -31,11 +31,11 @@ export const handlers = [
             },
             status: '完了',
             assigned_user: {
-              'id': 1,
+              'id': 2,
               'username': 'Takuya'
             },
-            scheduled_date: '2022/06/08',
-            result_date: '2022/06/08',
+            scheduled_date: '2022-06-08',
+            result_date: '2022-06-09',
             result_time: 60,
           },
         ])

--- a/pages/create-task-page.tsx
+++ b/pages/create-task-page.tsx
@@ -23,7 +23,9 @@ const CreateTask: NextPage = () => {
         <h2 className="my-3 text-center text-xl font-semibold">
           Register Task
         </h2>
-        <TaskForm />
+        <section className="p-6 w-4/5 max-w-4xl bg-white rounded-md shadow-md">
+          <TaskForm />
+        </section>
         <Link href="/todo-page">
           <a>ToDoページへ戻る</a>
         </Link>

--- a/pages/todo-page.tsx
+++ b/pages/todo-page.tsx
@@ -1,5 +1,4 @@
-import { useState, useEffect } from 'react'
-// import { useRouter } from 'next/router'
+import { useState, useEffect, useContext } from 'react'
 import useSWR from 'swr'
 import { NextPage, GetStaticProps } from 'next'
 import Cookie from 'universal-cookie'
@@ -9,6 +8,8 @@ import Task from '../components/Task'
 import { getAllTaskData } from '../lib/tasks'
 import axios from 'axios'
 import Link from 'next/link'
+import Modal from '../components/Modal'
+import { TaskContextProvider } from '../context/TaskContext'
 
 const cookie = new Cookie()
 
@@ -29,7 +30,7 @@ const TodoList: NextPage<STATICPROPS> = ({ staticTasks }) => {
 
   const { data: tasks, mutate } = useSWR('taskFetch', axiosFetcher, {
     fallbackData: staticTasks,
-    // revalidateOnMount: true,
+    revalidateOnMount: true,
   })
 
   useEffect(() => {
@@ -41,17 +42,20 @@ const TodoList: NextPage<STATICPROPS> = ({ staticTasks }) => {
     }
   }, [])
   return (
-    <Layout title="ToDo">
-      <div className="text-2xl font-bold text-slate-700 my-6">ToDo Page</div>
-      <section className="p-6 w-4/5 max-w-4xl bg-white rounded-md shadow-md">
-        <ul>
-          {tasks && tasks.map((task) => <Task key={task.id} {...task} />)}
-        </ul>
-      </section>
-      <Link href="/create-task-page">
-        <a>新規Task登録</a>
-      </Link>
-    </Layout>
+    <TaskContextProvider>
+      <Layout title="ToDo">
+        <div className="text-2xl font-bold text-slate-700 my-6">ToDo Page</div>
+        <section className="p-6 w-4/5 max-w-4xl bg-white rounded-md shadow-md">
+          <ul>
+            {tasks && tasks.map((task) => <Task key={task.id} task={task} />)}
+          </ul>
+        </section>
+        <Link href="/create-task-page">
+          <a>新規Task登録</a>
+        </Link>
+        <Modal mutate={mutate} />
+      </Layout>
+    </TaskContextProvider>
   )
 }
 export default TodoList


### PR DESCRIPTION
Task更新フォーム作成
・UserDropdownコンポーネントをTaskFormに適用
・updateTaskのAPI PUTリクエストを実装
・TaskContextを使用し、todo-pageの各コンポーネントから共通でStateへアクセス